### PR TITLE
Fix: коректно изчисляване на цената на доставката с други мерни единици освен kg

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -138,7 +138,7 @@ class Delivery_With_Econt_Helper
 
 			$price = $item->get_total() + $item->get_total_tax();
 			$quantity = intval($item->get_quantity());
-			$weight = floatval($product->get_weight());
+			$weight = floatval($product->get_weight()) * Delivery_With_Econt_Shipping::weight_unit_fixer();
 			$product_name = $product->get_name();
 
 			$data['items'][] = [

--- a/includes/class-delivery-with-econt-shipping.php
+++ b/includes/class-delivery-with-econt-shipping.php
@@ -107,7 +107,7 @@ class Delivery_With_Econt_Shipping extends WC_Shipping_Method
         // Build order data
         $order = array();
         $order['order_total'] = DWEH()->econt_calculate_cart_price($econt_cart);
-        $order['order_weight'] = WC()->cart->get_cart_contents_weight();
+        $order['order_weight'] = WC()->cart->get_cart_contents_weight() * self::weight_unit_fixer();
         $order['pack_count'] = 1;
         $order['order_currency'] = get_woocommerce_currency();
         $order['id_shop'] = $options['store_id'];
@@ -130,6 +130,22 @@ class Delivery_With_Econt_Shipping extends WC_Shipping_Method
         wp_send_json($full_url);
     }
 
+	public static function weight_unit_fixer() {
+        $weight_unit = get_option('woocommerce_weight_unit');
+        switch ($weight_unit) {
+            case 'kg':
+                return 1;
+            case 'g':
+                return 0.001;
+            case 'lbs':
+                return 0.453592;
+            case 'oz':
+                return 0.0283495;
+            default:
+                return 1; // Default to kg if unknown
+        }
+    }
+	
     public static function render_form_button($checkout){
             return;
     }

--- a/includes/class-delivery-with-econt-shipping.php
+++ b/includes/class-delivery-with-econt-shipping.php
@@ -108,6 +108,7 @@ class Delivery_With_Econt_Shipping extends WC_Shipping_Method
         $order = array();
         $order['order_total'] = DWEH()->econt_calculate_cart_price($econt_cart);
         $order['order_weight'] = WC()->cart->get_cart_contents_weight() * self::weight_unit_fixer();
+		$order['order_weight'] = $order['order_weight'] > 0.005 ? $order['order_weight'] : 0.005; // Minimum weight is 5gr.
         $order['pack_count'] = 1;
         $order['order_currency'] = get_woocommerce_currency();
         $order['id_shop'] = $options['store_id'];

--- a/includes/class-econt-blocks.php
+++ b/includes/class-econt-blocks.php
@@ -43,7 +43,7 @@ class Econt_Blocks {
 
 	    foreach (WC()->cart->get_cart() as $cart_item) {
 		    $product = $cart_item['data'];
-		    $weight = $product->get_weight();
+		    $weight = $product->get_weight() * Delivery_With_Econt_Shipping::weight_unit_fixer();
 		    $quantity = (int)$cart_item['quantity'];
 
 		    // Check if weight is an empty string


### PR DESCRIPTION
**Проблем:** Когато мерните единици на магазина в WooCommerce са настроени да са различни от кг, а са напр.гр, унция или паунд, цената на доставката не се изчислява коректно. 
**Решение:** Добавена е функция, която проверява настройката на WooCommerce и връща коригиращ фактор. Той от своя страна се използва при всяко извикване на функции за взимане на тегло за да бъдат превърнати в кг, както работи плъгина.